### PR TITLE
A comma added before the URI for fn write_to

### DIFF
--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -210,7 +210,7 @@ impl VariantStream {
         if self.is_i_frame {
             write!(w, "#EXT-X-I-FRAME-STREAM-INF:")?;
             self.write_stream_inf_common_attributes(w)?;
-            writeln!(w, "URI=\"{}\"", self.uri)
+            writeln!(w, ",URI=\"{}\"", self.uri)
         }
         else {
             write!(w, "#EXT-X-STREAM-INF:")?;


### PR DESCRIPTION
This is related to Issue https://github.com/rutgersc/m3u8-rs/issues/6
