### PR TITLE
Upgraded macros to Nom 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m3u8-rs"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["Rutger"]
 readme = "README.md"
 repository = "https://github.com/rutgersc/m3u8-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ documentation = "https://rutgersc.github.io/doc/m3u8_rs/index.html"
 license = "MIT"
 
 [dependencies]
-nom = "^1.2.3"
+nom = "5.1.0"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To use this library, add the following dependency to `Cargo.toml`:
 
 ```toml
 [dependencies]
-m3u8-rs = "1.0.2"
+m3u8-rs = "1.0.6"
 ```
 
 And add the crate to `lib.rs`

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ file.read_to_end(&mut bytes).unwrap();
 let parsed = m3u8_rs::parse_playlist(&bytes);
 
 match parsed {
-    IResult::Done(i, Playlist::MasterPlaylist(pl)) => println!("Master playlist:\n{}", pl),
-    IResult::Done(i, Playlist::MediaPlaylist(pl)) => println!("Media playlist:\n{}", pl),
+    IResult::Ok((i, Playlist::MasterPlaylist(pl))) => println!("Master playlist:\n{}", pl),
+    IResult::Ok((i, Playlist::MediaPlaylist(pl))) => println!("Media playlist:\n{}", pl),
     IResult::Error(e) =>  panic!("Parsing error: \n{}", e),
     IResult::Incomplete(e) => panic!("Parsing error: \n{:?}", e),
 }

--- a/examples/with_nom_result.rs
+++ b/examples/with_nom_result.rs
@@ -3,7 +3,6 @@ extern crate m3u8_rs;
 
 use m3u8_rs::playlist::{Playlist};
 use std::io::Read;
-use nom::IResult;
 
 fn main() {
     let mut file = std::fs::File::open("playlist.m3u8").unwrap();
@@ -13,9 +12,8 @@ fn main() {
     let parsed = m3u8_rs::parse_playlist(&bytes);
 
     let playlist = match parsed {
-        IResult::Done(i, playlist) => playlist,
-        IResult::Error(e) =>  panic!("Parsing error: \n{}", e),
-        IResult::Incomplete(e) => panic!("Parsing error: \n{:?}", e),
+        Result::Ok((i, playlist)) => playlist,
+        Result::Err(e) =>  panic!("Parsing error: \n{}", e),
     };
 
     match playlist {
@@ -32,9 +30,8 @@ fn main_alt() {
     let parsed = m3u8_rs::parse_playlist(&bytes);
 
     match parsed {
-        IResult::Done(i, Playlist::MasterPlaylist(pl)) => println!("Master playlist:\n{:?}", pl),
-        IResult::Done(i, Playlist::MediaPlaylist(pl)) => println!("Media playlist:\n{:?}", pl),
-        IResult::Error(e) =>  panic!("Parsing error: \n{}", e),
-        IResult::Incomplete(e) => panic!("Parsing error: \n{:?}", e),
+        Result::Ok((i, Playlist::MasterPlaylist(pl))) => println!("Master playlist:\n{:?}", pl),
+        Result::Ok((i, Playlist::MediaPlaylist(pl))) => println!("Media playlist:\n{:?}", pl),
+        Result::Err(e) =>  panic!("Parsing error: \n{}", e),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //!     let mut file = std::fs::File::open("masterplaylist.m3u8").unwrap();
 //!     let mut bytes: Vec<u8> = Vec::new();
 //!     file.read_to_end(&mut bytes).unwrap();
-//!     
+//!
 //!     if let IResult::Done(_, pl) = m3u8_rs::parse_master_playlist(&bytes) {
 //!         println!("{:?}", pl);
 //!     }
@@ -61,7 +61,7 @@
 //! use m3u8_rs::playlist::{MediaPlaylist, MediaPlaylistType, MediaSegment};
 //!
 //! fn main() {
-//!     let playlist = MediaPlaylist { 
+//!     let playlist = MediaPlaylist {
 //!         version: 6,
 //!         target_duration: 3.0,
 //!         media_sequence: 338559,
@@ -78,10 +78,10 @@
 //!         ],
 //!         ..Default::default()
 //!     };
-//! 
+//!
 //!     //let mut v: Vec<u8> = Vec::new();
 //!     //playlist.write_to(&mut v).unwrap();
-//! 
+//!
 //!     //let mut file = std::fs::File::open("playlist.m3u8").unwrap();
 //!     //playlist.write_to(&mut file).unwrap();
 //! }
@@ -131,9 +131,8 @@ use playlist::*;
 /// }
 pub fn parse_playlist(input: &[u8]) -> IResult<&[u8], Playlist> {
     match is_master_playlist(input) {
-        // XXX: get rid of the local `map` to be able to `use` this
-        true => nom::combinator::map(parse_master_playlist, Playlist::MasterPlaylist)(input),
-        false => nom::combinator::map(parse_media_playlist, Playlist::MediaPlaylist)(input),
+        true => map(parse_master_playlist, Playlist::MasterPlaylist)(input),
+        false =>map(parse_media_playlist, Playlist::MediaPlaylist)(input),
     }
 }
 
@@ -412,8 +411,8 @@ pub fn media_segment_tag(input: &[u8]) -> IResult<&[u8], SegmentTag> {
       map!(do_parse!(tag!("#EXTINF:") >> e:duration_title_tag >> (e)), |(a,b)| SegmentTag::Extinf(a,b))
     | map!(do_parse!(tag!("#EXT-X-BYTERANGE:") >> r:byte_range_val >> (r)), SegmentTag::ByteRange)
     | map!(tag!("#EXT-X-DISCONTINUITY"), |_| SegmentTag::Discontinuity)
-    | map!(do_parse!(tag!("#EXT-X-KEY:") >> k:key >> (k)), SegmentTag::Key)
-    | map!(do_parse!(tag!("#EXT-X-MAP:") >> m:map >> (m)), SegmentTag::Map)
+    | map!(do_parse!(tag!("#EXT-X-KEY:") >> k: key >> (k)), SegmentTag::Key)
+    | map!(do_parse!(tag!("#EXT-X-MAP:") >> m: extmap >> (m)), SegmentTag::Map)
     | map!(do_parse!(tag!("#EXT-X-PROGRAM-DATE-TIME:") >> t:consume_line >> (t)), SegmentTag::ProgramDateTime)
     | map!(do_parse!(tag!("#EXT-X-DATE-RANGE:") >> t:consume_line >> (t)), SegmentTag::DateRange)
 
@@ -438,7 +437,7 @@ named!(pub duration_title_tag<(f32, Option<String>)>,
 
 named!(pub key<Key>, map!(key_value_pairs, Key::from_hashmap));
 
-named!(pub map<Map>, map!(key_value_pairs, Map::from_hashmap));
+named!(pub extmap<Map>, map!(key_value_pairs, Map::from_hashmap));
 
 // -----------------------------------------------------------------------------------------------
 // Basic tags

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ use nom::character::complete::{digit1, multispace0, space0 };
 use nom::{IResult};
 use nom::{ delimited,none_of,peek,is_not,complete,terminated,tag,
            alt,do_parse,opt,named,map,map_res,eof,many0,take,take_until,char};
+use nom::combinator::map;
 
 use std::str;
 use std::f32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ named!(pub is_master_playlist_tag_line(&[u8]) -> Option<(bool, String)>,
         tag: opt!(alt!(
                   map!(tag!("#EXT-X-STREAM-INF"),         |t| (true, t))
                 | map!(tag!("#EXT-X-I-FRAME-STREAM-INF"), |t| (true, t))
-                | map!(tag!("#EXT-X-MEDIA"),              |t| (true, t))
+                | map!(terminated!(tag!("#EXT-X-MEDIA"), is_not!("-")), |t| (true, t)) // terminated!() to prevent matching with #EXT-X-MEDIA-SEQUENCE for which we have a separate pattern below
                 | map!(tag!("#EXT-X-SESSION-KEY"),        |t| (true, t))
                 | map!(tag!("#EXT-X-SESSION-DATA"),       |t| (true, t))
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ pub fn parse_playlist_res(input: &[u8]) -> Result<Playlist, IResult<&[u8], Playl
 
 /// Parse input as a master playlist
 pub fn parse_master_playlist(input: &[u8]) -> IResult<&[u8], MasterPlaylist> {
-    nom::combinator::map(parse_master_playlist_tags, MasterPlaylist::from_tags)(input)
+    map(parse_master_playlist_tags, MasterPlaylist::from_tags)(input)
 }
 
 /// Parse input as a master playlist
@@ -180,7 +180,7 @@ pub fn parse_master_playlist_res(input: &[u8]) -> Result<MasterPlaylist, IResult
 
 /// Parse input as a media playlist
 pub fn parse_media_playlist(input: &[u8]) -> IResult<&[u8], MediaPlaylist> {
-    nom::combinator::map(parse_media_playlist_tags, MediaPlaylist::from_tags)(input)
+    map(parse_media_playlist_tags, MediaPlaylist::from_tags)(input)
 }
 
 /// Parse input as a media playlist

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -623,7 +623,7 @@ impl MediaSegment {
         if let Some(ref v) = self.title {
             writeln!(w, "{}", v)?;
         } else {
-            write!(w, "\n");
+            write!(w, "\n")?;
         }
 
         writeln!(w, "{}", self.uri)

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -210,7 +210,7 @@ impl VariantStream {
         if self.is_i_frame {
             write!(w, "#EXT-X-I-FRAME-STREAM-INF:")?;
             self.write_stream_inf_common_attributes(w)?;
-            writeln!(w, "URI=\"{}\"", self.uri)
+            writeln!(w, ",URI=\"{}\"", self.uri)
         }
         else {
             write!(w, "#EXT-X-STREAM-INF:")?;

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -622,6 +622,8 @@ impl MediaSegment {
 
         if let Some(ref v) = self.title {
             writeln!(w, "{}", v)?;
+        } else {
+            write!(w, "\n");
         }
 
         writeln!(w, "{}", self.uri)

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -732,7 +732,7 @@ impl From<String> for ByteRange {
 impl<'a> From<&'a str> for ByteRange {
     fn from(s: &'a str) -> Self {
         match byte_range_val(s.as_bytes()) {
-            IResult::Done(_, br) => br,
+            IResult::Ok((_, br)) => br,
             _ => panic!("Should not happen"),
         }
     }

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -479,6 +479,8 @@ impl MediaPlaylist {
                             next_segment.uri = u;
                             media_playlist.segments.push(next_segment);
                             next_segment = MediaSegment::empty();
+                            encryption_key = None;
+                            map = None;
                         }
                         _ => (),
                     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -42,7 +42,7 @@ fn print_parse_playlist_test(playlist_name: &str) -> bool {
     println!("Parsing playlist file: {:?}", playlist_name);
     let parsed = parse_playlist(input.as_bytes());
 
-    if let IResult::Done(i,o) = parsed {
+    if let Result::Ok((i,o)) = parsed {
         println!("{:?}", o);
         true
     }
@@ -117,9 +117,9 @@ fn playlist_types() {
         let input = getm3u(path);
         let is_master = is_master_playlist(input.as_bytes());
 
-        assert!(path.to_lowercase().contains("master") == is_master);
-
         println!("{:?} = {:?}", path, is_master);
+
+        assert!(path.to_lowercase().contains("master") == is_master);     
     }
 }
 
@@ -147,7 +147,7 @@ fn test_key_value_pairs_trailing_equals() {
 fn test_key_value_pairs_multiple_quoted_values() {
     assert_eq!(
         key_value_pairs(b"BANDWIDTH=86000,URI=\"low/iframe.m3u8\",PROGRAM-ID=1,RESOLUTION=\"1x1\",VIDEO=1\nrest"),
-        IResult::Done(
+        Result::Ok((
             "\nrest".as_bytes(),
             vec![
                 ("BANDWIDTH".to_string(), "86000".to_string()),
@@ -156,7 +156,7 @@ fn test_key_value_pairs_multiple_quoted_values() {
                 ("RESOLUTION".to_string(), "1x1".to_string()),
                 ("VIDEO".to_string(), "1".to_string())
             ].into_iter().collect::<HashMap<String,String>>()
-        )
+        ))
     );
 }
 
@@ -177,10 +177,10 @@ fn test_key_value_pairs() {
 fn test_key_value_pair() {
     assert_eq!(
         key_value_pair(b"PROGRAM-ID=1,rest"),
-        IResult::Done(
+        Result::Ok((
             "rest".as_bytes(),
             ("PROGRAM-ID".to_string(), "1".to_string())
-        )
+        )) 
     );
 }
 
@@ -188,7 +188,7 @@ fn test_key_value_pair() {
 fn comment() {
     assert_eq!(
         comment_tag(b"#Hello\nxxx"),
-        IResult::Done("xxx".as_bytes(), "Hello".to_string())
+        Result::Ok(("xxx".as_bytes(), "Hello".to_string()))
     );
 }
 
@@ -196,21 +196,39 @@ fn comment() {
 fn quotes() {
     assert_eq!(
         quoted(b"\"value\"rest"),
-        IResult::Done("rest".as_bytes(), "value".to_string())
+        Result::Ok(("rest".as_bytes(), "value".to_string()))
     );
 }
 
 #[test]
-fn consume_empty_line() {
-    let line = consume_line(b"\r\nrest");
-    println!("{:?}", line);
+fn consume_line_empty() {
+    assert_eq!(
+        consume_line(b"\r\nrest"),
+        Result::Err(nom::Err::Error(("\r\nrest".as_bytes(), nom::error::ErrorKind::IsNot))) 
+    );
+}
+
+#[test]
+fn consume_line_n() {
+    assert_eq!(
+        consume_line(b"before\nrest"),
+        Result::Ok(("rest".as_bytes(), "before".into()))
+    );
+}
+
+#[test]
+fn consume_line_rn() {
+    assert_eq!(
+        consume_line(b"before\r\nrest"),
+        Result::Ok(("rest".as_bytes(), "before".into()))
+    );
 }
 
 #[test]
 fn float_() {
     assert_eq!(
         float(b"33.22rest"),
-        IResult::Done("rest".as_bytes(), 33.22f32)
+        Result::Ok(("rest".as_bytes(), 33.22f32))
     );
 }
 
@@ -218,7 +236,7 @@ fn float_() {
 fn float_no_decimal() {
     assert_eq!(
         float(b"33rest"),
-        IResult::Done("rest".as_bytes(), 33f32)
+        Result::Ok(("rest".as_bytes(), 33f32))
     );
 }
 
@@ -226,7 +244,7 @@ fn float_no_decimal() {
 fn float_should_ignore_trailing_dot() {
     assert_eq!(
         float(b"33.rest"),
-        IResult::Done(".rest".as_bytes(), 33f32)
+        Result::Ok((".rest".as_bytes(), 33f32))
     );
 }
 
@@ -234,7 +252,7 @@ fn float_should_ignore_trailing_dot() {
 fn parse_duration_title() {
     assert_eq!(
         duration_title_tag(b"2.002,title\nrest"),
-        IResult::Done("rest".as_bytes(), (2.002f32, Some("title".to_string())))
+        Result::Ok(("rest".as_bytes(), (2.002f32, Some("title".to_string()))))
     );
 }
 
@@ -279,7 +297,7 @@ fn create_and_parse_master_playlist_full() {
                 uri: "masterplaylist-uri".into(),
                 bandwidth: "10010010".into(),
                 average_bandwidth: Some("10010010".into()),
-                codecs: "TheCODEC".into(),
+                codecs: Some("TheCODEC".into()),
                 resolution: Some("1000x3000".into()),
                 frame_rate: Some("60".into()),
                 audio: Some("audio".into()),


### PR DESCRIPTION
Changes:

- `IResult::Done` -> `IResult::Ok`
- `chain!` -> `do_parse!`
-- slightly different syntax with `?` ->  `opt!`
-- `mut` for `chain!` is gone, got to work around that
- `digit` -> `digit1`
- `space?` -> `space0`
- `multispace?` -> `multispace0`
- `many0!()` -> `many0!(complete!())`
- `take_until_either!` -> `is_not!`
- `take_until_and_consume!` -> `take_until!` + `take!(1)`
- `take_until_either_and_consume!` -> `is_not!` + `take!(1)`
- some `map()` needed re-shuffling

This PR also has the tag duplication fix in media manifest (#9 )