### PR TITLE
The `TYPE` attribute uses `CLOSED-CAPTIONS` and not `CLOSEDCAPTIONS`

### DIFF
--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -279,7 +279,7 @@ impl FromStr for AlternativeMediaType {
             "AUDIO" => Ok(AlternativeMediaType::Audio),
             "VIDEO" => Ok(AlternativeMediaType::Video),
             "SUBTITLES" => Ok(AlternativeMediaType::Subtitles),
-            "CLOSEDCAPTIONS" => Ok(AlternativeMediaType::ClosedCaptions),
+            "CLOSED-CAPTIONS" => Ok(AlternativeMediaType::ClosedCaptions),
             _ => Err(format!(
                 "Unable to create AlternativeMediaType from {:?}",
                 s
@@ -303,7 +303,7 @@ impl fmt::Display for AlternativeMediaType {
                 AlternativeMediaType::Audio => "AUDIO",
                 AlternativeMediaType::Video => "VIDEO",
                 AlternativeMediaType::Subtitles => "SUBTITLES",
-                AlternativeMediaType::ClosedCaptions => "CLOSEDCAPTIONS",
+                AlternativeMediaType::ClosedCaptions => "CLOSED-CAPTIONS",
             }
         )
     }


### PR DESCRIPTION
See https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis-10#section-4.4.6.1