### PR TITLE
Use `u64` instead of `i32` for byte ranges and sequence numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ pub struct MasterPlaylist {
 pub struct MediaPlaylist {
     pub version: usize,
     pub target_duration: f32,
-    pub media_sequence: i32,
+    pub media_sequence: u64,
     pub segments: Vec<MediaSegment>,
-    pub discontinuity_sequence: i32,
+    pub discontinuity_sequence: u64,
     pub end_list: bool,
     pub playlist_type: MediaPlaylistType,
     pub i_frames_only: bool,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -343,8 +343,8 @@ enum MediaPlaylistTag {
     Version(usize),
     Segment(SegmentTag),
     TargetDuration(f32),
-    MediaSequence(i32),
-    DiscontinuitySequence(i32),
+    MediaSequence(u64),
+    DiscontinuitySequence(u64),
     EndList,
     PlaylistType(MediaPlaylistType),
     IFramesOnly,
@@ -644,11 +644,11 @@ fn consume_line(i: &[u8]) -> IResult<&[u8], String> {
     )(i)
 }
 
-fn number(i: &[u8]) -> IResult<&[u8], i32> {
+fn number(i: &[u8]) -> IResult<&[u8], u64> {
     map_res(take_while1(is_digit), |s| {
         // Can't fail because we validated it above already
         let s = str::from_utf8(s).unwrap();
-        str::parse::<i32>(s)
+        str::parse::<u64>(s)
     })(i)
 }
 

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -401,10 +401,10 @@ pub struct MediaPlaylist {
     /// `#EXT-X-TARGETDURATION:<s>`
     pub target_duration: f32,
     /// `#EXT-X-MEDIA-SEQUENCE:<number>`
-    pub media_sequence: i32,
+    pub media_sequence: u64,
     pub segments: Vec<MediaSegment>,
     /// `#EXT-X-DISCONTINUITY-SEQUENCE:<number>`
-    pub discontinuity_sequence: i32,
+    pub discontinuity_sequence: u64,
     /// `#EXT-X-ENDLIST`
     pub end_list: bool,
     /// `#EXT-X-PLAYLIST-TYPE`
@@ -637,8 +637,8 @@ impl Map {
 /// URI line that follows it in the Playlist.
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct ByteRange {
-    pub length: i32,
-    pub offset: Option<i32>,
+    pub length: u64,
+    pub offset: Option<u64>,
 }
 
 impl ByteRange {


### PR DESCRIPTION
Fixes https://github.com/rutgersc/m3u8-rs/issues/39