### PR TITLE
enum types for non-binary attributes

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,0 +1,159 @@
+use crate::attributes::QuotedOrUnquoted::{Quoted, Unquoted};
+use std::fmt;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum QuotedOrUnquoted {
+    Unquoted(String),
+    Quoted(String),
+}
+
+impl Default for QuotedOrUnquoted {
+    fn default() -> Self {
+        Quoted(String::new())
+    }
+}
+
+impl From<&str> for QuotedOrUnquoted {
+    fn from(s: &str) -> Self {
+        if s.starts_with('"') && s.ends_with('"') {
+            return Quoted(s.trim_matches('"').to_string());
+        }
+        Unquoted(s.to_string())
+    }
+}
+
+impl fmt::Display for QuotedOrUnquoted {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Unquoted(s) => write!(f, "{}", s),
+            Quoted(u) => write!(f, "{}", u),
+        }
+    }
+}
+
+// EXT-X-KEY
+//
+// METHOD
+// The value is an enumerated-string that specifies the encryption
+// method. The methods defined are: NONE, AES-128, and SAMPLE-AES.
+#[allow(non_camel_case_types)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum KeyMethod {
+    None,
+    AES_128,
+    SAMPLE_AES,
+    Enum(String),
+}
+
+impl Default for KeyMethod {
+    fn default() -> Self {
+        KeyMethod::None
+    }
+}
+
+impl From<QuotedOrUnquoted> for KeyMethod {
+    fn from(s: QuotedOrUnquoted) -> Self {
+        match s {
+            QuotedOrUnquoted::Unquoted(s) if s == "NONE" => KeyMethod::None,
+            QuotedOrUnquoted::Unquoted(s) if s == "AES-128" => KeyMethod::AES_128,
+            QuotedOrUnquoted::Unquoted(s) if s == "SAMPLE-AES" => KeyMethod::SAMPLE_AES,
+            _ => KeyMethod::Enum(s.to_string()),
+        }
+    }
+}
+impl From<&str> for KeyMethod {
+    fn from(s: &str) -> Self {
+        QuotedOrUnquoted::from(s).into()
+    }
+}
+
+impl fmt::Display for KeyMethod {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            KeyMethod::None => write!(f, "NONE"),
+            KeyMethod::AES_128 => write!(f, "AES-128"),
+            KeyMethod::SAMPLE_AES => write!(f, "SAMPLE-AES"),
+            KeyMethod::Enum(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+// EXT-X-STREAM-INF:
+//
+// HDCP-LEVEL
+// The value is an enumerated-string; valid strings are TYPE-0, TYPE-
+// 1, and NONE
+#[allow(non_camel_case_types)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum HdcpLevel {
+    Type0,
+    Type1,
+    None,
+    Enum(String),
+}
+
+impl From<QuotedOrUnquoted> for HdcpLevel {
+    fn from(s: QuotedOrUnquoted) -> Self {
+        match s {
+            QuotedOrUnquoted::Unquoted(s) if s == "NONE" => HdcpLevel::None,
+            QuotedOrUnquoted::Unquoted(s) if s == "TYPE-0" => HdcpLevel::Type0,
+            QuotedOrUnquoted::Unquoted(s) if s == "TYPE-1" => HdcpLevel::Type1,
+            _ => HdcpLevel::Enum(s.to_string()),
+        }
+    }
+}
+
+impl From<&str> for HdcpLevel {
+    fn from(s: &str) -> Self {
+        QuotedOrUnquoted::from(s).into()
+    }
+}
+
+impl fmt::Display for HdcpLevel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            HdcpLevel::None => write!(f, "NONE"),
+            HdcpLevel::Type0 => write!(f, "TYPE-0"),
+            HdcpLevel::Type1 => write!(f, "Type-1"),
+            HdcpLevel::Enum(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+// EXT-X-STREAM-INF
+//
+// CLOSED-CAPTIONS
+// The value can be either a quoted-string or an enumerated-string
+// with the value NONE.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ClosedCaptions {
+    None,
+    GroupId(String),
+    Enum(String),
+}
+
+impl From<QuotedOrUnquoted> for ClosedCaptions {
+    fn from(s: QuotedOrUnquoted) -> Self {
+        match s {
+            QuotedOrUnquoted::Unquoted(s) if s == "NONE" => ClosedCaptions::None,
+            QuotedOrUnquoted::Quoted(gid) => ClosedCaptions::GroupId(gid),
+            QuotedOrUnquoted::Unquoted(e) => ClosedCaptions::Enum(e),
+        }
+    }
+}
+
+impl From<&str> for ClosedCaptions {
+    fn from(s: &str) -> Self {
+        QuotedOrUnquoted::from(s).into()
+    }
+}
+
+impl fmt::Display for ClosedCaptions {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ClosedCaptions::None => write!(f, "NONE"),
+            ClosedCaptions::GroupId(gid) => write!(f, "{}", gid),
+            ClosedCaptions::Enum(e) => write!(f, "{}", e),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,3 +73,6 @@ mod parser;
 
 #[cfg(feature = "parser")]
 pub use self::parser::*;
+
+pub mod attributes;
+pub use playlist::*;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,11 +8,11 @@ use nom::combinator::{complete, eof, map, map_res, opt, peek};
 use nom::multi::{fold_many0, many0};
 use nom::sequence::{delimited, pair, preceded, terminated, tuple};
 
+use crate::attributes::*;
 use crate::playlist::*;
 use nom::IResult;
 use std::collections::HashMap;
 use std::f32;
-use std::fmt;
 use std::result::Result;
 use std::str;
 use std::str::FromStr;
@@ -614,40 +614,6 @@ fn key_value_pairs(i: &[u8]) -> IResult<&[u8], HashMap<String, QuotedOrUnquoted>
             acc
         },
     )(i)
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum QuotedOrUnquoted {
-    Unquoted(String),
-    Quoted(String),
-}
-
-impl Default for QuotedOrUnquoted {
-    fn default() -> Self {
-        QuotedOrUnquoted::Quoted(String::new())
-    }
-}
-
-impl From<&str> for QuotedOrUnquoted {
-    fn from(s: &str) -> Self {
-        if s.starts_with('"') && s.ends_with('"') {
-            return QuotedOrUnquoted::Quoted(s.trim_matches('"').to_string());
-        }
-        QuotedOrUnquoted::Unquoted(s.to_string())
-    }
-}
-
-impl fmt::Display for QuotedOrUnquoted {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                QuotedOrUnquoted::Unquoted(s) => s,
-                QuotedOrUnquoted::Quoted(u) => u,
-            }
-        )
-    }
 }
 
 fn key_value_pair(i: &[u8]) -> IResult<&[u8], (String, QuotedOrUnquoted)> {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,6 @@
 #![allow(unused_variables, unused_imports, dead_code)]
 
+use m3u8_rs::attributes::*;
 use m3u8_rs::*;
 use nom::AsBytes;
 use std::collections::HashMap;
@@ -321,6 +322,7 @@ fn create_and_parse_media_playlist_full() {
             }],
         }],
     });
+    println!("hello");
     let playlist_parsed = print_create_and_parse_playlist(&mut playlist_original);
     assert_eq!(playlist_original, playlist_parsed);
 }


### PR DESCRIPTION
I audited the spec and implemented enums for all non-binary attributes that are currently implemented:

* HDCP-LEVEL
* CLOSED-CAPTIONS
* METHOD

I don't believe we need to add these for binary attributes, that are either YES or NO and the absence means NO.

If you don't believe it's sufficient, feel free to add more enums.