### PR TITLE
`EXT-X-VERSION` tag may be absent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! use m3u8_rs::{MediaPlaylist, MediaPlaylistType, MediaSegment};
 //!
 //! let playlist = MediaPlaylist {
-//!     version: 6,
+//!     version: Some(6),
 //!     target_duration: 3.0,
 //!     media_sequence: 338559,
 //!     discontinuity_sequence: 1234,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -249,7 +249,7 @@ fn master_playlist_from_tags(mut tags: Vec<MasterPlaylistTag>) -> MasterPlaylist
     while let Some(tag) = tags.pop() {
         match tag {
             MasterPlaylistTag::Version(v) => {
-                master_playlist.version = v;
+                master_playlist.version = Some(v);
             }
             MasterPlaylistTag::AlternativeMedia(v) => {
                 master_playlist.alternatives.push(v);
@@ -396,7 +396,7 @@ fn media_playlist_from_tags(mut tags: Vec<MediaPlaylistTag>) -> MediaPlaylist {
     while let Some(tag) = tags.pop() {
         match tag {
             MediaPlaylistTag::Version(v) => {
-                media_playlist.version = v;
+                media_playlist.version = Some(v);
             }
             MediaPlaylistTag::TargetDuration(d) => {
                 media_playlist.target_duration = d;

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -71,7 +71,7 @@ impl Playlist {
 /// describes a different version of the same content.
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct MasterPlaylist {
-    pub version: usize,
+    pub version: Option<usize>,
     pub variants: Vec<VariantStream>,
     pub session_data: Vec<SessionData>,
     pub session_key: Vec<SessionKey>,
@@ -87,7 +87,11 @@ impl MasterPlaylist {
     }
 
     pub fn write_to<T: Write>(&self, w: &mut T) -> std::io::Result<()> {
-        writeln!(w, "#EXTM3U\n#EXT-X-VERSION:{}", self.version)?;
+        writeln!(w, "#EXTM3U\n")?;
+
+        if let Some(ref v) = self.version {
+            writeln!(w, "#EXT-X-VERSION:{}", v)?;
+        }
 
         for alternative in &self.alternatives {
             alternative.write_to(w)?;
@@ -403,7 +407,7 @@ impl SessionData {
 /// sequentially will play the multimedia presentation.
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct MediaPlaylist {
-    pub version: usize,
+    pub version: Option<usize>,
     /// `#EXT-X-TARGETDURATION:<s>`
     pub target_duration: f32,
     /// `#EXT-X-MEDIA-SEQUENCE:<number>`
@@ -425,7 +429,11 @@ pub struct MediaPlaylist {
 
 impl MediaPlaylist {
     pub fn write_to<T: Write>(&self, w: &mut T) -> std::io::Result<()> {
-        writeln!(w, "#EXTM3U\n#EXT-X-VERSION:{}", self.version)?;
+        writeln!(w, "#EXTM3U\n")?;
+
+        if let Some(ref v) = self.version {
+            writeln!(w, "#EXT-X-VERSION:{}", v)?;
+        }
         writeln!(w, "#EXT-X-TARGETDURATION:{}", self.target_duration)?;
 
         if self.media_sequence != 0 {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -199,7 +199,7 @@ fn create_and_parse_master_playlist_empty() {
 #[test]
 fn create_and_parse_master_playlist_full() {
     let mut playlist_original = Playlist::MasterPlaylist(MasterPlaylist {
-        version: 6,
+        version: Some(6),
         alternatives: vec![AlternativeMedia {
             media_type: AlternativeMediaType::Audio,
             uri: Some("alt-media-uri".into()),
@@ -263,6 +263,7 @@ fn create_and_parse_media_playlist_empty() {
 #[test]
 fn create_and_parse_media_playlist_single_segment() {
     let mut playlist_original = Playlist::MediaPlaylist(MediaPlaylist {
+        target_duration: 2.0,
         segments: vec![MediaSegment {
             uri: "20140311T113819-01-338559live.ts".into(),
             duration: 2.002,
@@ -278,7 +279,7 @@ fn create_and_parse_media_playlist_single_segment() {
 #[test]
 fn create_and_parse_media_playlist_full() {
     let mut playlist_original = Playlist::MediaPlaylist(MediaPlaylist {
-        version: 4,
+        version: Some(4),
         target_duration: 3.0,
         media_sequence: 338559,
         discontinuity_sequence: 1234,


### PR DESCRIPTION
```
   It MUST appear in all Playlists containing tags or attributes that
   are not compatible with protocol version 1 to support
   interoperability with older clients.
```
Thus, the tag absence is allowed and means version 1. Today if the tag is absent in the original manifest it is rendered with `0` value, which breaks players. With the fix, if the tag was not included it will not be rendered.