### PR TITLE
Remove additional newline after "#EXTM3U" added in previous commit

### DIFF
--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -429,7 +429,7 @@ pub struct MediaPlaylist {
 
 impl MediaPlaylist {
     pub fn write_to<T: Write>(&self, w: &mut T) -> std::io::Result<()> {
-        writeln!(w, "#EXTM3U\n")?;
+        writeln!(w, "#EXTM3U")?;
 
         if let Some(ref v) = self.version {
             writeln!(w, "#EXT-X-VERSION:{}", v)?;


### PR DESCRIPTION
See https://github.com/rutgersc/m3u8-rs/pull/50#discussion_r851802322