### PR TITLE
Release 5.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m3u8-rs"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["Rutger"]
 readme = "README.md"
 repository = "https://github.com/rutgersc/m3u8-rs"


### PR DESCRIPTION
@rutgersc I'd `cargo upload` the new version and push a corresponding tag once this is merged.

I also noticed that this repo has no tags, so I'll also create one for 5.0.0 and 4.0.0 at least, and maybe for older ones too if that's fine for you.