### PR TITLE
Incomplete manifest can cause an infinite loop

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -143,7 +143,7 @@ fn contains_master_tag(input: &[u8]) -> Option<(bool, String)> {
     let mut is_master_opt = None;
     let mut current_input: &[u8] = input;
 
-    while is_master_opt == None {
+    while is_master_opt.is_none() && !current_input.is_empty() {
         match is_master_playlist_tag_line(current_input) {
             IResult::Ok((rest, result)) => {
                 current_input = rest;
@@ -984,6 +984,14 @@ mod tests {
         assert_eq!(
             duration_title_tag(b"2.002,title\nrest"),
             Result::Ok(("rest".as_bytes(), (2.002f32, Some("title".to_string()))))
+        );
+    }
+
+    #[test]
+    fn incomplete_manifest() {
+        assert_eq!(
+            is_master_playlist("#EXTM3U\n#EXT-X-VERSION:5\n#EXT-X-TARGETDU".as_bytes()),
+            false
         );
     }
 }


### PR DESCRIPTION
* When a manifest is incomplete or damaged, the `contains_master_tag` may go into infinite loop if `is_master_playlist_tag_line` detection hasn't had a chance to succeed.
* Clippy recommendation is implemented to use `.is_none()` instead of comparing to literal `Option::None`. 
* Test added