### PR TITLE
allow millisecond accuracy for EXT-X-PROGRAM-DATE-TIME

### DIFF
--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -869,7 +869,11 @@ impl MediaSegment {
             writeln!(w)?;
         }
         if let Some(ref v) = self.program_date_time {
-            writeln!(w, "#EXT-X-PROGRAM-DATE-TIME:{}", v.to_rfc3339())?;
+            writeln!(
+                w,
+                "#EXT-X-PROGRAM-DATE-TIME:{}",
+                v.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+            )?;
         }
         if let Some(ref v) = self.daterange {
             write!(w, "#EXT-X-DATERANGE:")?;


### PR DESCRIPTION
adds millisecond value for MediaSegment EXT-X-PROGRAM-DATE-TIME per

https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.4.6

>  It SHOULD indicate a time zone and fractional parts of seconds, to at least millisecond accuracy.