### PR TITLE
Allowing empty comments

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -218,7 +218,7 @@ enum MasterPlaylistTag {
     SessionKey(SessionKey),
     Start(Start),
     IndependentSegments,
-    Comment(String),
+    Comment(Option<String>),
     Uri(String),
     Unknown(ExtTag),
 }
@@ -487,7 +487,7 @@ enum SegmentTag {
     ProgramDateTime(chrono::DateTime<chrono::FixedOffset>),
     DateRange(DateRange),
     Unknown(ExtTag),
-    Comment(String),
+    Comment(Option<String>),
     Uri(String),
 }
 
@@ -609,10 +609,10 @@ fn ext_tag(i: &[u8]) -> IResult<&[u8], ExtTag> {
     )(i)
 }
 
-fn comment_tag(i: &[u8]) -> IResult<&[u8], String> {
+fn comment_tag(i: &[u8]) -> IResult<&[u8], Option<String>> {
     map(
         pair(
-            preceded(char('#'), map_res(is_not("\r\n"), from_utf8_slice)),
+            preceded(char('#'), opt(map_res(is_not("\r\n"), from_utf8_slice))),
             take(1usize),
         ),
         |(text, _)| text,
@@ -929,7 +929,7 @@ mod tests {
     fn comment() {
         assert_eq!(
             comment_tag(b"#Hello\nxxx"),
-            Result::Ok(("xxx".as_bytes(), "Hello".to_string()))
+            Result::Ok(("xxx".as_bytes(), Some("Hello".to_string())))
         );
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -935,10 +935,7 @@ mod tests {
 
     #[test]
     fn empty_comment() {
-        assert_eq!(
-            comment_tag(b"#\nxxx"),
-            Result::Ok(("xxx".as_bytes(), None))
-        );
+        assert_eq!(comment_tag(b"#\nxxx"), Result::Ok(("xxx".as_bytes(), None)));
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -934,6 +934,14 @@ mod tests {
     }
 
     #[test]
+    fn empty_comment() {
+        assert_eq!(
+            comment_tag(b"#\nxxx"),
+            Result::Ok(("xxx".as_bytes(), None))
+        );
+    }
+
+    #[test]
     fn quotes() {
         assert_eq!(
             quoted(b"\"value\"rest"),


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc8216#section-4.1

```
Lines that start with the character '#' are either comments or tags.
   Tags begin with #EXT.  They are case sensitive.  All other lines that
   begin with '#' are comments and SHOULD be ignored.
```

We're currently only recognizing comments with a text in them. When a comment has no text (empty), it becomes an issue.  eg
```
#EXTM3U
# Created with Bento4 mp4-dash.py, VERSION=2.0.0-640
#
```
the 2nd line is processed fine.
the 3rd line though is not matching as a comment in `fn comment_tag()` and is ingested as if it was a segment URI with `0` duration. 

This PR is addressing the issue
