### PR TITLE
Serialize unknown_tag in MediaPlaylist

### DIFF
--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -761,6 +761,11 @@ impl MediaPlaylist {
         if self.i_frames_only {
             writeln!(w, "#EXT-X-I-FRAMES-ONLY")?;
         }
+
+        for unknown_tag in &self.unknown_tags {
+            writeln!(w, "{}", unknown_tag)?;
+        }
+
         if let Some(ref start) = self.start {
             start.write_to(w)?;
         }

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -761,13 +761,11 @@ impl MediaPlaylist {
         if self.i_frames_only {
             writeln!(w, "#EXT-X-I-FRAMES-ONLY")?;
         }
-
-        for unknown_tag in &self.unknown_tags {
-            writeln!(w, "{}", unknown_tag)?;
-        }
-
         if let Some(ref start) = self.start {
             start.write_to(w)?;
+        }
+        for unknown_tag in &self.unknown_tags {
+            writeln!(w, "{}", unknown_tag)?;
         }
         for segment in &self.segments {
             segment.write_to(w)?;


### PR DESCRIPTION
MediaPlaylist unknown_tag should be serialized
I suggest to serialize unknown_tag before the serialization of the list of segments