### PR TITLE
Support multiple #EXT-X-KEY tags

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -391,7 +391,7 @@ fn media_playlist_tag(i: &[u8]) -> IResult<&[u8], MediaPlaylistTag> {
 fn media_playlist_from_tags(mut tags: Vec<MediaPlaylistTag>) -> MediaPlaylist {
     let mut media_playlist = MediaPlaylist::default();
     let mut next_segment = MediaSegment::empty();
-    let mut encryption_key = None;
+    let mut encryption_keys = vec![];
     let mut map = None;
 
     while let Some(tag) = tags.pop() {
@@ -435,7 +435,7 @@ fn media_playlist_from_tags(mut tags: Vec<MediaPlaylistTag>) -> MediaPlaylist {
                     next_segment.discontinuity = true;
                 }
                 SegmentTag::Key(k) => {
-                    encryption_key = Some(k);
+                    encryption_keys.push(k);
                 }
                 SegmentTag::Map(m) => {
                     map = Some(m);
@@ -450,12 +450,12 @@ fn media_playlist_from_tags(mut tags: Vec<MediaPlaylistTag>) -> MediaPlaylist {
                     next_segment.unknown_tags.push(t);
                 }
                 SegmentTag::Uri(u) => {
-                    next_segment.key = encryption_key.clone();
+                    next_segment.keys = encryption_keys;
                     next_segment.map = map.clone();
                     next_segment.uri = u;
                     media_playlist.segments.push(next_segment);
                     next_segment = MediaSegment::empty();
-                    encryption_key = None;
+                    encryption_keys = vec![];
                     map = None;
                 }
                 _ => (),

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -838,7 +838,7 @@ pub struct MediaSegment {
     /// `#EXT-X-DISCONTINUITY`
     pub discontinuity: bool,
     /// `#EXT-X-KEY:<attribute-list>`
-    pub key: Option<Key>,
+    pub keys: Vec<Key>,
     /// `#EXT-X-MAP:<attribute-list>`
     pub map: Option<Map>,
     /// `#EXT-X-PROGRAM-DATE-TIME:<YYYY-MM-DDThh:mm:ssZ>`
@@ -863,7 +863,7 @@ impl MediaSegment {
         if self.discontinuity {
             writeln!(w, "#EXT-X-DISCONTINUITY")?;
         }
-        if let Some(ref key) = self.key {
+        for key in &self.keys {
             write!(w, "#EXT-X-KEY:")?;
             key.write_attributes_to(w)?;
             writeln!(w)?;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -373,13 +373,22 @@ fn create_and_parse_media_playlist_full() {
                 offset: Some(4559),
             }),
             discontinuity: true,
-            key: Some(Key {
-                method: KeyMethod::None,
-                uri: Some("https://secure.domain.com".into()),
-                iv: Some("0xb059217aa2649ce170b734".into()),
-                keyformat: Some("xXkeyformatXx".into()),
-                keyformatversions: Some("xXFormatVers".into()),
-            }),
+            keys: vec![
+                Key {
+                    method: KeyMethod::None,
+                    uri: Some("https://secure.domain.com".into()),
+                    iv: Some("0xb059217aa2649ce170b734".into()),
+                    keyformat: Some("xXkeyformatXx".into()),
+                    keyformatversions: Some("xXFormatVers".into()),
+                },
+                Key {
+                    method: KeyMethod::AES128,
+                    uri: Some("skd://c2VjdXJlLmRvbWFpbi5jb20=".into()),
+                    iv: Some("0xb059217aa2649ce170b734".into()),
+                    keyformat: Some("com.apple.streamingkeydelivery".into()),
+                    keyformatversions: Some("1".into()),
+                },
+            ],
             map: Some(Map {
                 uri: "www.map-uri.com".into(),
                 byte_range: Some(ByteRange {


### PR DESCRIPTION
Why need this change?
* When parsing and then building the m3u8 below, some `#EXT-X-KEY` tags are missing.

```
#EXTM3U
#EXT-X-VERSION:6
#EXT-X-TARGETDURATION:11
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-MAP:URI="5d9aec6dea24.mp4",BYTERANGE="3327@0"
#EXTINF:4.338,
#EXT-X-BYTERANGE:61342@3383
5d9aec6dea24.mp4
#EXTINF:4.505,
#EXT-X-BYTERANGE:83830
5d9aec6dea24.mp4
#EXT-X-DISCONTINUITY
#EXT-X-MAP:URI="8b94105ce572.mp4",BYTERANGE="4102@0"
#EXT-X-KEY:METHOD=SAMPLE-AES,URI="data:text/plain;charset=UTF-16;base64,U...A==",IV=0x123456789abcdef123456789abcdef,KEYFORMATVERSIONS="1",KEYFORMAT="com.microsoft.playready"
#EXT-X-KEY:METHOD=SAMPLE-AES,URI="data:text/plain;base64,A...Y=",KEYID=0x123456789abcdef123456789abcdef,IV=0x123456789abcdef123456789abcdef,KEYFORMATVERSIONS="1",KEYFORMAT="urn:uuid:12345678-9abc-def0-1234-123456789abc"
#EXT-X-KEY:METHOD=SAMPLE-AES,URI="skd://X...Q==",KEYFORMATVERSIONS="1",KEYFORMAT="com.apple.streamingkeydelivery"
#EXTINF:6.506,
#EXT-X-BYTERANGE:40676@12570
8b94105ce572.mp4
#EXTINF:4.463,
#EXT-X-BYTERANGE:105347
8b94105ce572.mp4
...
```

Changes made:
* Support multiple `#EXT-X-KEY` tags